### PR TITLE
Fix wrong return type

### DIFF
--- a/MailMotor.php
+++ b/MailMotor.php
@@ -23,7 +23,7 @@ class MailMotor
      * @param string $listId - If you want to use a custom list id
      * @return string
      */
-    public function getListId(string $listId = null): string
+    public function getListId(string $listId = null): ?string
     {
         return ($listId == null) ? $this->listId : $listId;
     }

--- a/MailMotor.php
+++ b/MailMotor.php
@@ -9,7 +9,7 @@ namespace MailMotor\Bundle\MailMotorBundle;
  */
 class MailMotor
 {
-    /** @var string - The default list id */
+    /** @var string|null - The default list id */
     protected $listId;
 
     public function __construct(?string $listId)
@@ -20,8 +20,8 @@ class MailMotor
     /**
      * Get list id
      *
-     * @param string $listId - If you want to use a custom list id
-     * @return string
+     * @param string|null $listId - If you want to use a custom list id
+     * @return string|null
      */
     public function getListId(string $listId = null): ?string
     {


### PR DESCRIPTION
Return value of MailMotor\Bundle\MailMotorBundle\MailMotor::getListId() must be of the type string, null returned