### PR TITLE
Symfony 4 fixes

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,6 +10,7 @@ services:
     # Factories
     mailmotor.factory:
         class: MailMotor\Bundle\MailMotorBundle\Factory\MailMotorFactory
+        public: true
         arguments:
             - "@service_container"
             - "%mailmotor.mail_engine%"
@@ -21,5 +22,6 @@ services:
     # Fallback gateway when no mail-engine is selected (at default)
     mailmotor.not_implemented.subscriber.gateway:
         class: MailMotor\Bundle\MailMotorBundle\Gateway\NotImplementedSubscriberGateway
+        public: true
         tags:
             - { name: mailmotor.subscriber_gateway, alias: not_implemented }


### PR DESCRIPTION
With Symfony 4, event listeners that use the mailmotor subscriber throw some errors.

For example: `The "mailmotor.factory" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the container directly and use dependency injection instead.`

Marking these as public fixes the errors.